### PR TITLE
setting jib-maven-plugin to 3.1.1 for Concourse build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,10 +189,10 @@
                 <artifactId>sonar-maven-plugin</artifactId>
                 <version>${sonar-maven-plugin.version}</version>
             </plugin>
-						<plugin>
-							<groupId>com.google.cloud.tools</groupId>
-							<artifactId>jib-maven-plugin</artifactId>
-							<version>3.1.4</version>
+            <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-maven-plugin</artifactId>
+                <version>3.1.1</version>
             </plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
The docker-build job is failing in Concourse.
All our other 'Thundercat' services have the version at 3.1.1
If this resolves it in 3pa-web, I'll do the same in 3pa-api.

https://ci.platform.aws.chdev.org/teams/team-thundercats/pipelines/tpa-register-api/jobs/docker-build/builds/2
![Screenshot 2022-07-14 at 8 30 53 am](https://user-images.githubusercontent.com/2736331/178926937-7d7cb2e6-cc7c-48bd-b113-da9d89877a03.png)

